### PR TITLE
bugfix: make the backtest compatible with user specific data (eg: futures market)

### DIFF
--- a/finrl/trade/backtest.py
+++ b/finrl/trade/backtest.py
@@ -56,9 +56,10 @@ def backtest_plot(
     )
 
     baseline_returns = get_daily_return(baseline_df, value_col_name="close")
+    shared_index = test_returns.index & baseline_returns.index
     with pyfolio.plotting.plotting_context(font_scale=1.1):
         pyfolio.create_full_tear_sheet(
-            returns=test_returns, benchmark_rets=baseline_returns, set_context=False
+            returns=test_returns.loc[shared_index], benchmark_rets=baseline_returns.loc[shared_index], set_context=False
         )
 
 


### PR DESCRIPTION
Bugfix: When applying the FinRL-Library to user specific data (eg: futures market), at the stage of doing backtesst and comparing the test result with baseline, the "test_returns" might have different dates in its index from "baseline_returns", which will occur the below error. This change fix the issue. And if the "test_returns" has exact the same index as "baseline_returns", the change won't do anything.
https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike