### PR TITLE
Change from trading_calenders to exchange_calendars

### DIFF
--- a/finrl/neo_finrl/data_processors/processor_alpaca.py
+++ b/finrl/neo_finrl/data_processors/processor_alpaca.py
@@ -2,7 +2,7 @@ import alpaca_trade_api as tradeapi
 import pandas as pd
 import numpy as np
 from stockstats import StockDataFrame as Sdf
-import trading_calendars as tc
+import exchange_calendars as tc
 import pytz
 
 class AlpacaProcessor():

--- a/finrl/neo_finrl/data_processors/processor_yahoofinance.py
+++ b/finrl/neo_finrl/data_processors/processor_yahoofinance.py
@@ -4,7 +4,7 @@ import pandas as pd
 import yfinance as yf
 import numpy as np
 from stockstats import StockDataFrame as Sdf
-import trading_calendars as tc
+import exchange_calendars as tc
 import pytz
 
 class YahooFinanceProcessor():

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ tensorboardX
 gputil
 
 # market data & paper trading API
-trading_calendars
+exchange_calendars
 alpaca_trade_api
 ccxt
 jqdatasdk

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ except:
 
 setup(
     name="finrl",
-    version="0.3.1",
+    version="0.3.2",
     include_package_data=True,
     author="Hongyang Yang, Xiaoyang Liu",
     author_email="hy2500@columbia.edu",
@@ -44,6 +44,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],


### PR DESCRIPTION
trading_calenders has been marked unmaintained by developer. It is producing errors during build process on 3.9. Removed trading_calenders and replaced it with exchange_calenders