### PR TITLE
Update models.py

### DIFF
--- a/finrl/drl_agents/stablebaselines3/models.py
+++ b/finrl/drl_agents/stablebaselines3/models.py
@@ -49,7 +49,8 @@ class TensorboardCallback(BaseCallback):
         super(TensorboardCallback, self).__init__(verbose)
 
     def _on_step(self) -> bool:
-        self.logger.record(key='train/reward', value=self.locals['rewards'][0])
+        try: self.logger.record(key='train/reward', value=self.locals['rewards'][0])
+        except: self.logger.record(key='train/reward', value=self.locals['reward'][0])
         return True
 
 


### PR DESCRIPTION
The key 'rewards' throws a KeyError for DDPG for which the key 'rewards' works. To resolve that I suggest using the try-except way that tries the default key and uses the singular version of the key in case of the error.