### PR TITLE
 fixing divided by zero error in .std() in get_validation_sharpe  

### DIFF
--- a/finrl/drl_agents/stablebaselines3/models.py
+++ b/finrl/drl_agents/stablebaselines3/models.py
@@ -211,11 +211,14 @@ class DRLEnsembleAgent:
         df_total_value = pd.read_csv(
             f"results/account_value_validation_{model_name}_{iteration}.csv"
         )
-        return (
+        try:
+            return (
                 (4 ** 0.5)
                 * df_total_value["daily_return"].mean()
                 / df_total_value["daily_return"].std()
-        )
+            )
+        except:
+            return (0.0)
 
     def __init__(
             self,

--- a/finrl/drl_agents/stablebaselines3/models.py
+++ b/finrl/drl_agents/stablebaselines3/models.py
@@ -211,15 +211,18 @@ class DRLEnsembleAgent:
         df_total_value = pd.read_csv(
             f"results/account_value_validation_{model_name}_{iteration}.csv"
         )
-        try:
+        # If the agent did not make any transaction 
+        if df_total_value["daily_return"].var()==0:
+            if df_total_value["daily_return"].mean()>0:
+                return (np.inf)
+            else:
+                return (0.0)
+        else:
             return (
-                (4 ** 0.5)
-                * df_total_value["daily_return"].mean()
-                / df_total_value["daily_return"].std()
+                    (4 ** 0.5)
+                    * df_total_value["daily_return"].mean()
+                    / df_total_value["daily_return"].std()
             )
-        except:
-            return (0.0)
-
     def __init__(
             self,
             df,


### PR DESCRIPTION
As an enthusiast, I decided to run the method proposed in this [paper ](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3690996) on my own BTCUSDT 1h dataset, during the execution  I realized that in case of the agent doesn't make any deals (like NOP forever), the daily return variable of the agent would remain constant and equal to `0` so the program would be interrupted with a `divided by zero` error [in this line](https://github.com/AI4Finance-Foundation/FinRL/blob/28b4be8f1b0949739a4371785aa68aa7b98124af/finrl/drl_agents/stablebaselines3/models.py#L214) . So I decided to check it beforehand in the `get_validation_sharpe` method.