### PR TITLE
remove version restriction with `black`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,13 @@
 repos:
--   repo: https://github.com/ambv/black
+  - repo: https://github.com/ambv/black
     rev: stable
     hooks:
-    - id: black
-      language_version: python3.6
--   repo: https://gitlab.com/pycqa/flake8
+      - id: black
+  - repo: https://gitlab.com/pycqa/flake8
     rev: 4.0.1
     hooks:
-    - id: flake8
--   repo: https://github.com/pre-commit/mirrors-isort
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:
       - id: isort


### PR DESCRIPTION
As stated in [Contributing Guidences](https://github.com/AI4Finance-Foundation/FinRL/blob/master/tutorials/Contributing.md), one should use pre-commit hooks. The origin `.pre-commit-config.yaml` has a restriction that python must be 3.6 while python 3.6 is not fully supported in this repo. So I simply remove this restriction.