### PR TITLE
Fixing invalid PPO import from elegantrl lib

### DIFF
--- a/finrl/finrl_meta/env_stock_trading/env_stock_papertrading.py
+++ b/finrl/finrl_meta/env_stock_trading/env_stock_papertrading.py
@@ -18,7 +18,7 @@ class AlpacaPaperTrading():
         self.drl_lib = drl_lib
         if agent =='ppo':
             if drl_lib == 'elegantrl':              
-                from elegantrl.agents.agent import AgentPPO
+                from elegantrl.agents import AgentPPO
                 from elegantrl.train.run import Arguments, init_agent
                 #load agent
                 config = {'state_dim':state_dim,

--- a/tutorials/3-Practical/FinRL_PaperTrading_Demo.ipynb
+++ b/tutorials/3-Practical/FinRL_PaperTrading_Demo.ipynb
@@ -1477,7 +1477,7 @@
     "        self.drl_lib = drl_lib\n",
     "        if agent =='ppo':\n",
     "            if drl_lib == 'elegantrl':              \n",
-    "                from elegantrl.agents.agent import AgentPPO\n",
+    "                from elegantrl.agents import AgentPPO\n",
     "                from elegantrl.train.run import init_agent\n",
     "                from elegantrl.train.config import Arguments\n",
     "                #load agent\n",


### PR DESCRIPTION
There are a couple of invalid import from AgentPPo in the source code, and one of them exist in the AlpacaPaperTrading class that throws the error ModuleNotFound, with this PR it will be fixed

Error that will be fixed

![image](https://user-images.githubusercontent.com/35659426/161568790-ae2c513d-ea4c-4daf-a44e-11891b4bea7f.png)
