### PR TITLE
fix bug: self.sell_cost_pct is the list of costs

### DIFF
--- a/finrl/finrl_meta/env_stock_trading/env_stocktrading.py
+++ b/finrl/finrl_meta/env_stock_trading/env_stocktrading.py
@@ -136,7 +136,7 @@ class StockTradingEnv(gym.Env):
                         self.state[0] += sell_amount
                         self.state[index + self.stock_dim + 1] = 0
                         self.cost += (
-                            self.state[index + 1] * sell_num_shares * self.sell_cost_pct
+                            self.state[index + 1] * sell_num_shares * self.sell_cost_pct[index]
                         )
                         self.trades += 1
                     else:


### PR DESCRIPTION
Fix bug for issue: https://github.com/AI4Finance-Foundation/FinRL/issues/558 
`self.sell_cost_pct` is the cost list for all stocks, the index is missed, so error `TypeError: can't multiply sequence by non-int of type 'numpy.float64'` is raised when multiplied with other number. 

thx. @bruceyang @spencerromo @xiaoyang 