### PR TITLE
bug fix for running us stocks with alpaca and ppo,elegentRL with comm…

### DIFF
--- a/finrl/__init__.py
+++ b/finrl/__init__.py
@@ -1,0 +1,3 @@
+from finrl.train import train
+from finrl.test import test
+from finrl.trade import trade

--- a/finrl/config.py
+++ b/finrl/config.py
@@ -7,7 +7,7 @@ TENSORBOARD_LOG_DIR = "tensorboard_log"
 RESULTS_DIR = "results"
 
 # date format: '%Y-%m-%d'
-TRAIN_START_DATE = "2014-01-01"
+TRAIN_START_DATE = "2014-01-06" #bug fix: set Monday right, start date set 2014-01-01 ValueError: all the input array dimensions for the concatenation axis must match exactly, but along dimension 0, the array at index 0 has size 1658 and the array at index 1 has size 1657
 TRAIN_END_DATE = "2020-07-31"
 
 TEST_START_DATE = "2020-08-01"
@@ -54,7 +54,8 @@ ERL_PARAMS = {
     "seed": 312,
     "net_dimension": 512,
     "target_step": 5000,
-    "eval_gap": 30
+    "eval_gap": 30,
+    "eval_times": 64 #bug fix:KeyError: 'eval_times' line 68, in get_model model.eval_times = model_kwargs["eval_times"]
 }
 RLlib_PARAMS = {"lr": 5e-5, "train_batch_size": 500, "gamma": 0.99}
 

--- a/finrl/config_private.py
+++ b/finrl/config_private.py
@@ -1,0 +1,3 @@
+# parameters for data sources
+ALPACA_API_KEY = "XXX"  # your ALPACA_API_KEY
+ALPACA_API_SECRET = "XXX"  # your ALPACA_API_SECRET

--- a/finrl/config_tickers.py
+++ b/finrl/config_tickers.py
@@ -33,7 +33,7 @@ DOW_30_TICKER = [
     "WBA",
     "WMT",
     "DIS",
-    "DOW"
+   "DOW"
 ]
 
 # Nasdaq 100 constituents at 2019/01

--- a/finrl/finrl_meta/data_processors/processor_yahoofinance.py
+++ b/finrl/finrl_meta/data_processors/processor_yahoofinance.py
@@ -319,7 +319,8 @@ class YahooFinanceProcessor:
     def get_trading_days(self, start, end):
         nyse = tc.get_calendar("NYSE")
         df = nyse.sessions_in_range(
-            pd.Timestamp(start, tz=pytz.UTC), pd.Timestamp(end, tz=pytz.UTC)
+            # pd.Timestamp(start, tz=pytz.UTC), pd.Timestamp(end, tz=pytz.UTC)
+            pd.Timestamp(start), pd.Timestamp(end) #bug fix:ValueError: Parameter `start` received with timezone defined as 'UTC' although a Date must be timezone naive.
         )
         trading_days = []
         for day in df:

--- a/finrl/main.py
+++ b/finrl/main.py
@@ -3,6 +3,7 @@ from typing import List
 from argparse import ArgumentParser
 from finrl import config
 from finrl.config_tickers import DOW_30_TICKER
+from finrl.config_private import (ALPACA_API_KEY,ALPACA_API_SECRET)
 from finrl.config import (
     DATA_SAVE_DIR,
     TRAINED_MODEL_DIR,
@@ -18,8 +19,6 @@ from finrl.config import (
     ERL_PARAMS,
     RLlib_PARAMS,
     SAC_PARAMS,
-    ALPACA_API_KEY,
-    ALPACA_API_SECRET,
     ALPACA_API_BASE_URL,
 )
 


### PR DESCRIPTION
#bug fix:ValueError: Parameter `start` received with timezone defined as 'UTC' although a Date must be timezone naive.
#bug fix:KeyError: 'eval_times' line 68, in get_model model.eval_times = model_kwargs["eval_times"]
#bug fix: set Monday right, start date set 2014-01-01 ValueError: all the input array dimensions for the concatenation axis must match exactly, but along dimension 0, the array at index 0 has size 1658 and the array at index 1 has size 1657
#bug fix：module cannot be callable for finrl.train finrl.test finrl.trade
#add file config_private.py set private data 