### PR TITLE
Branch bug fix paper trading for us stocking with ppo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,4 @@ finrl_test.py
 test_plugplay.py
 papertrading_test.py
 alpaca_processor_test.py
+/finrl/config_private.py

--- a/finrl/config_private.py
+++ b/finrl/config_private.py
@@ -1,3 +1,0 @@
-# parameters for data sources
-ALPACA_API_KEY = "XXX"  # your ALPACA_API_KEY
-ALPACA_API_SECRET = "XXX"  # your ALPACA_API_SECRET

--- a/finrl/finrl_meta/data_processors/processor_yahoofinance.py
+++ b/finrl/finrl_meta/data_processors/processor_yahoofinance.py
@@ -48,7 +48,7 @@ class YahooFinanceProcessor:
         # Download and save the data in a pandas DataFrame:
         data_df = pd.DataFrame()
         for tic in ticker_list:
-            temp_df = yf.download(tic, start=start_date, end=end_date)
+            temp_df = yf.download(tic, start=start_date, end=end_date, interval=self.time_interval) #bug fix: add interval for download
             temp_df["tic"] = tic
             data_df = data_df.append(temp_df)
         # reset the index, we want to use numbers as index instead of dates

--- a/finrl/finrl_meta/env_stock_trading/env_stock_papertrading.py
+++ b/finrl/finrl_meta/env_stock_trading/env_stock_papertrading.py
@@ -20,7 +20,7 @@ class AlpacaPaperTrading():
             if drl_lib == 'elegantrl':              
                 from elegantrl.agents import AgentPPO
                 from elegantrl.train.run import init_agent
-                from elegantrl.run import Arguments
+                from elegantrl.train.config import Arguments #bug fix:ModuleNotFoundError: No module named 'elegantrl.run'
                 #load agent
                 config = {'state_dim':state_dim,
                             'action_dim':action_dim,}
@@ -88,6 +88,8 @@ class AlpacaPaperTrading():
             self.time_interval = 60 * 5
         elif time_interval == '15Min':
             self.time_interval = 60 * 15
+        elif time_interval == '1D': #bug fix:1D ValueError: Time interval input is NOT supported yet. Maybe any other better ways
+            self.time_interval = 24*60*60
         else:
             raise ValueError('Time interval input is NOT supported yet.')
         

--- a/finrl/main.py
+++ b/finrl/main.py
@@ -111,9 +111,11 @@ def main():
             API_KEY=ALPACA_API_KEY,
             API_SECRET=ALPACA_API_SECRET,
             API_BASE_URL=ALPACA_API_BASE_URL,
-            trade_mode='backtesting',
+            trade_mode='paper_trading',
             if_vix=True,
             kwargs=kwargs,
+            state_dim=len(DOW_30_TICKER) * (len(INDICATORS) + 3) + 3,#bug fix: for ppo add dimension of state/observations space =  len(stocks)* len(INDICATORS) + 3+ 3*len(stocks)
+            action_dim=len(DOW_30_TICKER)#bug fix: for ppo add dimension of action space = len(stocks)
         )
     else:
         raise ValueError("Wrong mode.")

--- a/finrl/trade.py
+++ b/finrl/trade.py
@@ -23,13 +23,14 @@ def trade(start_date, end_date, ticker_list, data_source, time_interval,
             raise ValueError('Fail to read parameters. Please check inputs for net_dim, cwd, state_dim, action_dim.')
 
         # initialize paper trading env
-        AlpacaPaperTrading(ticker_list, time_interval, drl_lib, model_name,
+        paper_trading = AlpacaPaperTrading(ticker_list, time_interval, drl_lib, model_name,
                            cwd, net_dim, state_dim, action_dim,
                            API_KEY, API_SECRET, API_BASE_URL,
                            technical_indicator_list, turbulence_thresh=30,
                            max_stock=1e2, latency=None)
 
-        AlpacaPaperTrading.run()  # run paper trading
+        # AlpacaPaperTrading.run()  # run paper trading
+        paper_trading.run();#bug fix run is a instance function not static
 
     else:
         raise ValueError("Invalid mode input! Please input either 'backtesting' or 'paper_trading'.")


### PR DESCRIPTION
fix bugs for paper trading errors:
#bug fix: add interval for download in  [processor_yahoofinance.py]
#bug fix:ModuleNotFoundError: No module named 'elegantrl.run' in [env_stock_papertrading.py]
#bug fix:1D ValueError: Time interval input is NOT supported yet. Maybe any other better ways in [env_stock_papertrading.py]
#bug fix: for ppo paper_trading add dimension of state/observations space =  len(stocks)* len(INDICATORS) + 3+ 3*len(stocks) in[main.py]
#bug fix: for ppo paper_trading add dimension of action space = len(stocks) in[main.py]
#bug fix run is a instance function not static in[trade.py]



