### PR TITLE
Restrict exchange-calendars version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ ccxt==1.66.32  # make sure that >=1.66.32
 elegantrl
 
 # market data & paper trading API
-exchange_calendars
+exchange_calendars==3.6.3 # because raise exception with 4.1.1, success tested with 3.6.3
 gputil
 gym>=0.17
 jqdatasdk


### PR DESCRIPTION
exchange-calendars 4.1.1 raise exception in `clean_data()`:
```
ValueError: Parameter `start` received with timezone defined as 'UTC' although a Date must be timezone naive.
```
It run with exchange-calendars 3.6.3.
I have added a restriction on exchange-calendars version.