### PR TITLE
Install swig for wheel building

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ setuptools==59.5.0
 stable-baselines3[extra]
 stockstats>=0.4.0
 tensorboardX
+swig
 wheel>=0.33.6
 wrds
 yfinance

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,8 +32,8 @@ scikit-learn>=0.21.0
 setuptools==59.5.0
 stable-baselines3[extra]
 stockstats>=0.4.0
-tensorboardX
 swig
+tensorboardX
 wheel>=0.33.6
 wrds
 yfinance


### PR DESCRIPTION
While building the wheel, we need to first install the swig and then do pip install wheel