### PR TITLE
Include python version <3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ keywords=["Reinforcement Learning", "Finance"]
 github = "https://github.com/finrl/finrl-library"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.8"
+python = ">=3.7,<3.9"
 pyfolio = {git="https://github.com/quantopian/pyfolio.git#egg=pyfolio-0.9.2"}
 elegantrl = {git="https://github.com/AI4Finance-Foundation/ElegantRL.git#egg=elegantrl"}
 alpaca_trade_api = ">=2.1.0"


### PR DESCRIPTION
I am running Python 3.8.10 successfully, but the build of the finrl wheel recently has given an error:
ERROR: Package 'finrl-0.3.5' requires a different Python: 3.8.10 not in '>=3.7,<3.8'

Please can you extend the range