### PR TITLE
Fix hstack issue   issue 770

### DIFF
--- a/finrl/meta/data_processors/processor_alpaca.py
+++ b/finrl/meta/data_processors/processor_alpaca.py
@@ -50,8 +50,8 @@ class AlpacaProcessor:
         # filter opening time of the New York Stock Exchange (NYSE) (from 9:30 am to 4:00 pm) if time_interval < 1D
         day_delta = 86400000000000  # pd.Timedelta('1D').delta == 86400000000000
         if pd.Timedelta(time_interval).delta < day_delta:
-            NYSE_open_hour = "13:30"  # in UTC
-            NYSE_close_hour = "19:59"  # in UTC
+            NYSE_open_hour = "14:30"  # in UTC
+            NYSE_close_hour = "20:59"  # in UTC
             data_df = barset.between_time(NYSE_open_hour, NYSE_close_hour)
         else:
             data_df = barset

--- a/tutorials/FinRL_PaperTrading_Demo_refactored.py
+++ b/tutorials/FinRL_PaperTrading_Demo_refactored.py
@@ -124,7 +124,7 @@ state_dim = (
     1 + 2 + 3 * action_dim + len(INDICATORS) * action_dim
 )  # Calculate the DRL state dimension manually for paper trading. amount + (turbulence, turbulence_bool) + (price, shares, cd (holding time)) * stock_dim + tech_dim
 
-paper_trading_erl = AlpacaPaperTrading(
+paper_trading_erl = PaperTradingAlpaca(
     ticker_list=DOW_30_TICKER,
     time_interval="1Min",
     drl_lib="elegantrl",


### PR DESCRIPTION
Fix for https://github.com/AI4Finance-Foundation/FinRL/issues/770

The open and close trading times were an hour ahead of what they should be.

NYSE trading times are 14:30 - 20:59 UTC.

This caused the hstack() error in df_to_array() as the number of rows of prices per tic were not the same so arrays could not be stacked columnwise.

                price_array = np.hstack(
                    [price_array, df[df.tic == tic][["close"]].values]
                ) 