### PR TITLE
Bug Fix on Yahoo Finance Data Downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Technical indicators: 'macd', 'boll_ub', 'boll_lb', 'rsi_30', 'dx_30', 'close_30
 - The environment layer includes not only a collection of historical data APIs, but also live trading APIs. They are reconfigured into standard OpenAI gym-style environments. Moreover, it incorporates market frictions and allows users to customize the trading time granularity.
 
 
-## Tutorials 
+## Tutorials
 
 + [Towardsdatascience] [Deep Reinforcement Learning for Automated Stock Trading](https://towardsdatascience.com/deep-reinforcement-learning-for-automated-stock-trading-f1dad0126a02)
 
@@ -298,7 +298,7 @@ Thank you!
 
 ### Sponsorship
 
-Welcome gift money to support AI4Finance, a non-profit community. 
+Welcome gift money to support AI4Finance, a non-profit community.
 
 Network: USDT-TRC20
 

--- a/finrl/meta/data_processors/processor_yahoofinance.py
+++ b/finrl/meta/data_processors/processor_yahoofinance.py
@@ -98,18 +98,19 @@ class YahooFinanceProcessor:
         delta = timedelta(days=1)
         data_df = pd.DataFrame()
         for tic in ticker_list:
+            current_tic_start_date = start_date
             while (
-                start_date <= end_date
+                current_tic_start_date <= end_date
             ):  # downloading daily to workaround yfinance only allowing  max 7 calendar (not trading) days of 1 min data per single download
                 temp_df = yf.download(
                     tic,
-                    start=start_date,
-                    end=start_date + delta,
+                    start=current_tic_start_date,
+                    end=current_tic_start_date + delta,
                     interval=self.time_interval,
                 )
                 temp_df["tic"] = tic
                 data_df = pd.concat([data_df, temp_df])
-                start_date += delta
+                current_tic_start_date += delta
 
         data_df = data_df.reset_index().drop(columns=["Adj Close"])
         # convert the column names to match processor_alpaca.py as far as poss


### PR DESCRIPTION
The current version of downloader has a bug that only downloads data from the first ticker, and skips the rest.  This patch should fix the bug.