### PR TITLE
enable proxy when downloading yahoo finance data

### DIFF
--- a/finrl/meta/data_processors/processor_yahoofinance.py
+++ b/finrl/meta/data_processors/processor_yahoofinance.py
@@ -79,8 +79,12 @@ class YahooFinanceProcessor:
         return time_interval
 
     def download_data(
-            self, ticker_list: list[str], start_date: str, end_date: str, time_interval: str,
-            proxy: Union[str, dict] = None
+        self,
+        ticker_list: list[str],
+        start_date: str,
+        end_date: str,
+        time_interval: str,
+        proxy: str | dict = None,
     ) -> pd.DataFrame:
         time_interval = self.convert_interval(time_interval)
 
@@ -102,7 +106,7 @@ class YahooFinanceProcessor:
                     start=start_date,
                     end=start_date + delta,
                     interval=self.time_interval,
-                    proxy=proxy
+                    proxy=proxy,
                 )
                 temp_df["tic"] = tic
                 data_df = pd.concat([data_df, temp_df])

--- a/finrl/meta/data_processors/processor_yahoofinance.py
+++ b/finrl/meta/data_processors/processor_yahoofinance.py
@@ -79,7 +79,8 @@ class YahooFinanceProcessor:
         return time_interval
 
     def download_data(
-        self, ticker_list: list[str], start_date: str, end_date: str, time_interval: str
+            self, ticker_list: list[str], start_date: str, end_date: str, time_interval: str,
+            proxy: Union[str, dict] = None
     ) -> pd.DataFrame:
         time_interval = self.convert_interval(time_interval)
 
@@ -101,6 +102,7 @@ class YahooFinanceProcessor:
                     start=start_date,
                     end=start_date + delta,
                     interval=self.time_interval,
+                    proxy=proxy
                 )
                 temp_df["tic"] = tic
                 data_df = pd.concat([data_df, temp_df])


### PR DESCRIPTION
yahoo finance data is not accessible in China mainland, so i add a proxy which in supported in yfinance. You can pass a param which is the same as session param