### PR TITLE
Changed environment 'reset' interfaces to match the gymnasium interface.

### DIFF
--- a/finrl/meta/env_cryptocurrency_trading/env_btc_ccxt.py
+++ b/finrl/meta/env_cryptocurrency_trading/env_btc_ccxt.py
@@ -50,7 +50,12 @@ class BitcoinEnv:  # custom env
         self.target_return = 10
         self.max_step = self.price_ary.shape[0]
 
-    def reset(self) -> np.ndarray:
+    def reset(
+        self,
+        *,
+        seed = None,
+        options = None,
+    ) -> np.ndarray:
         self.day = 0
         self.day_price = self.price_ary[self.day]
         self.day_tech = self.tech_ary[self.day]

--- a/finrl/meta/env_cryptocurrency_trading/env_btc_ccxt.py
+++ b/finrl/meta/env_cryptocurrency_trading/env_btc_ccxt.py
@@ -53,8 +53,8 @@ class BitcoinEnv:  # custom env
     def reset(
         self,
         *,
-        seed = None,
-        options = None,
+        seed=None,
+        options=None,
     ) -> np.ndarray:
         self.day = 0
         self.day_price = self.price_ary[self.day]

--- a/finrl/meta/env_cryptocurrency_trading/env_multiple_crypto.py
+++ b/finrl/meta/env_cryptocurrency_trading/env_multiple_crypto.py
@@ -46,7 +46,12 @@ class CryptoEnv:  # custom env
         self.if_discrete = False
         self.target_return = 10
 
-    def reset(self) -> np.ndarray:
+    def reset(
+        self,
+        *,
+        seed = None,
+        options = None,
+    ) -> np.ndarray:
         self.time = self.lookback - 1
         self.current_price = self.price_array[self.time]
         self.current_tech = self.tech_array[self.time]

--- a/finrl/meta/env_cryptocurrency_trading/env_multiple_crypto.py
+++ b/finrl/meta/env_cryptocurrency_trading/env_multiple_crypto.py
@@ -49,8 +49,8 @@ class CryptoEnv:  # custom env
     def reset(
         self,
         *,
-        seed = None,
-        options = None,
+        seed=None,
+        options=None,
     ) -> np.ndarray:
         self.time = self.lookback - 1
         self.current_price = self.price_array[self.time]

--- a/finrl/meta/env_portfolio_allocation/env_portfolio.py
+++ b/finrl/meta/env_portfolio_allocation/env_portfolio.py
@@ -202,8 +202,8 @@ class StockPortfolioEnv(gym.Env):
     def reset(
         self,
         *,
-        seed = None,
-        options = None,
+        seed=None,
+        options=None,
     ):
         self.asset_memory = [self.initial_amount]
         self.day = 0

--- a/finrl/meta/env_portfolio_allocation/env_portfolio.py
+++ b/finrl/meta/env_portfolio_allocation/env_portfolio.py
@@ -199,7 +199,12 @@ class StockPortfolioEnv(gym.Env):
 
         return self.state, self.reward, self.terminal, {}
 
-    def reset(self):
+    def reset(
+        self,
+        *,
+        seed = None,
+        options = None,
+    ):
         self.asset_memory = [self.initial_amount]
         self.day = 0
         self.data = self.df.loc[self.day, :]

--- a/finrl/meta/env_stock_trading/env_nas100_wrds.py
+++ b/finrl/meta/env_stock_trading/env_nas100_wrds.py
@@ -90,7 +90,12 @@ class StockEnvNAS100:
         self.target_return = 2.2
         self.episode_return = 0.0
 
-    def reset(self):
+    def reset(
+        self,
+        *,
+        seed = None,
+        options = None,
+    ):
         self.day = 0
         price = self.price_ary[self.day]
 

--- a/finrl/meta/env_stock_trading/env_nas100_wrds.py
+++ b/finrl/meta/env_stock_trading/env_nas100_wrds.py
@@ -93,8 +93,8 @@ class StockEnvNAS100:
     def reset(
         self,
         *,
-        seed = None,
-        options = None,
+        seed=None,
+        options=None,
     ):
         self.day = 0
         price = self.price_ary[self.day]

--- a/finrl/meta/env_stock_trading/env_stock_papertrading.py
+++ b/finrl/meta/env_stock_trading/env_stock_papertrading.py
@@ -401,7 +401,12 @@ class StockEnvEmpty(gym.Env):
             low=-1, high=1, shape=(action_dim,), dtype=np.float32
         )
 
-    def reset(self):
+    def reset(
+        self,
+        *,
+        seed = None,
+        options = None,
+    ):
         return
 
     def step(self, actions):

--- a/finrl/meta/env_stock_trading/env_stock_papertrading.py
+++ b/finrl/meta/env_stock_trading/env_stock_papertrading.py
@@ -404,8 +404,8 @@ class StockEnvEmpty(gym.Env):
     def reset(
         self,
         *,
-        seed = None,
-        options = None,
+        seed=None,
+        options=None,
     ):
         return
 

--- a/finrl/meta/env_stock_trading/env_stocktrading.py
+++ b/finrl/meta/env_stock_trading/env_stocktrading.py
@@ -358,8 +358,8 @@ class StockTradingEnv(gym.Env):
     def reset(
         self,
         *,
-        seed = None,
-        options = None,
+        seed=None,
+        options=None,
     ):
         # initiate state
         self.state = self._initiate_state()

--- a/finrl/meta/env_stock_trading/env_stocktrading.py
+++ b/finrl/meta/env_stock_trading/env_stocktrading.py
@@ -355,7 +355,12 @@ class StockTradingEnv(gym.Env):
 
         return self.state, self.reward, self.terminal, False, {}
 
-    def reset(self):
+    def reset(
+        self,
+        *,
+        seed = None,
+        options = None,
+    ):
         # initiate state
         self.state = self._initiate_state()
 

--- a/finrl/meta/env_stock_trading/env_stocktrading_cashpenalty.py
+++ b/finrl/meta/env_stock_trading/env_stocktrading_cashpenalty.py
@@ -129,7 +129,12 @@ class StockTradingEnvCashpenalty(gym.Env):
     def closings(self):
         return np.array(self.get_date_vector(self.date_index, cols=["close"]))
 
-    def reset(self):
+    def reset(
+        self,
+        *,
+        seed = None,
+        options = None,
+    ):
         self.seed()
         self.sum_trades = 0
         if self.random_start:

--- a/finrl/meta/env_stock_trading/env_stocktrading_cashpenalty.py
+++ b/finrl/meta/env_stock_trading/env_stocktrading_cashpenalty.py
@@ -132,8 +132,8 @@ class StockTradingEnvCashpenalty(gym.Env):
     def reset(
         self,
         *,
-        seed = None,
-        options = None,
+        seed=None,
+        options=None,
     ):
         self.seed()
         self.sum_trades = 0

--- a/finrl/meta/env_stock_trading/env_stocktrading_np.py
+++ b/finrl/meta/env_stock_trading/env_stocktrading_np.py
@@ -80,8 +80,8 @@ class StockTradingEnv(gym.Env):
     def reset(
         self,
         *,
-        seed = None,
-        options = None,
+        seed=None,
+        options=None,
     ):
         self.day = 0
         price = self.price_ary[self.day]

--- a/finrl/meta/env_stock_trading/env_stocktrading_np.py
+++ b/finrl/meta/env_stock_trading/env_stocktrading_np.py
@@ -77,7 +77,12 @@ class StockTradingEnv(gym.Env):
             low=-1, high=1, shape=(self.action_dim,), dtype=np.float32
         )
 
-    def reset(self):
+    def reset(
+        self,
+        *,
+        seed = None,
+        options = None,
+    ):
         self.day = 0
         price = self.price_ary[self.day]
 

--- a/finrl/meta/env_stock_trading/env_stocktrading_stoploss.py
+++ b/finrl/meta/env_stock_trading/env_stocktrading_stoploss.py
@@ -131,7 +131,12 @@ class StockTradingEnvStopLoss(gym.Env):
     def current_step(self):
         return self.date_index - self.starting_point
 
-    def reset(self):
+    def reset(
+        self,
+        *,
+        seed = None,
+        options = None,
+    ):
         self.seed()
         self.sum_trades = 0
         self.actual_num_trades = 0

--- a/finrl/meta/env_stock_trading/env_stocktrading_stoploss.py
+++ b/finrl/meta/env_stock_trading/env_stocktrading_stoploss.py
@@ -134,8 +134,8 @@ class StockTradingEnvStopLoss(gym.Env):
     def reset(
         self,
         *,
-        seed = None,
-        options = None,
+        seed=None,
+        options=None,
     ):
         self.seed()
         self.sum_trades = 0

--- a/finrl/meta/paper_trading/alpaca.py
+++ b/finrl/meta/paper_trading/alpaca.py
@@ -413,8 +413,8 @@ class StockEnvEmpty(gym.Env):
     def reset(
         self,
         *,
-        seed = None,
-        options = None,
+        seed=None,
+        options=None,
     ):
         return
 

--- a/finrl/meta/paper_trading/alpaca.py
+++ b/finrl/meta/paper_trading/alpaca.py
@@ -410,7 +410,12 @@ class StockEnvEmpty(gym.Env):
             low=-1, high=1, shape=(action_dim,), dtype=np.float32
         )
 
-    def reset(self):
+    def reset(
+        self,
+        *,
+        seed = None,
+        options = None,
+    ):
         return
 
     def step(self, actions):

--- a/finrl/meta/paper_trading/common.py
+++ b/finrl/meta/paper_trading/common.py
@@ -403,8 +403,8 @@ class PendulumEnv(gym.Wrapper):  # a demo of custom gym env
     def reset(
         self,
         *,
-        seed = None,
-        options = None,
+        seed=None,
+        options=None,
     ) -> np.ndarray:  # reset the agent in env
         return self.env.reset()
 

--- a/finrl/meta/paper_trading/common.py
+++ b/finrl/meta/paper_trading/common.py
@@ -400,7 +400,12 @@ class PendulumEnv(gym.Wrapper):  # a demo of custom gym env
         self.action_dim = self.action_space.shape[0]  # feature number of action
         self.if_discrete = False  # discrete action or continuous action
 
-    def reset(self) -> np.ndarray:  # reset the agent in env
+    def reset(
+        self,
+        *,
+        seed = None,
+        options = None,
+    ) -> np.ndarray:  # reset the agent in env
         return self.env.reset()
 
     def step(


### PR DESCRIPTION
The "reset" function for each environment has been changed to match the gymnasium interface. This should address issues with external libraries that expect the full interface, such as stablebaselines3 and prevent such issues in future.