### PR TITLE
Reset self.day before initializing state, otherwise self.state is incorrectly initialized when reset is called.

### DIFF
--- a/finrl/meta/env_stock_trading/env_stocktrading.py
+++ b/finrl/meta/env_stock_trading/env_stocktrading.py
@@ -362,6 +362,8 @@ class StockTradingEnv(gym.Env):
         options=None,
     ):
         # initiate state
+        self.day = 0
+        self.data = self.df.loc[self.day, :]
         self.state = self._initiate_state()
 
         if self.initial:
@@ -381,8 +383,6 @@ class StockTradingEnv(gym.Env):
             )
             self.asset_memory = [previous_total_asset]
 
-        self.day = 0
-        self.data = self.df.loc[self.day, :]
         self.turbulence = 0
         self.cost = 0
         self.trades = 0


### PR DESCRIPTION
Currently StockTradingEnv.reset() sets self.day to 0 after initializing state, which leads to incorrect state initialization as the state contains the stock prices of last day instead of the first day. This commit aims to fix this issue.