### PR TITLE
Update installation.rst to add swig for WSL

### DIFF
--- a/docs/source/start/installation.rst
+++ b/docs/source/start/installation.rst
@@ -206,7 +206,7 @@ Open an ubuntu terminal and type:
 
 .. code-block:: bash
 
-   sudo apt-get update && sudo apt-get install cmake libopenmpi-dev python3-dev zlib1g-dev libgl1-mesa-glx
+   sudo apt-get update && sudo apt-get install cmake libopenmpi-dev python3-dev zlib1g-dev libgl1-mesa-glx swig
 
 Step 4: Install `FinRL <https://github.com/AI4Finance-Foundation/FinRL>`_
 --------------------------------------------------------------------------


### PR DESCRIPTION
swig is needed for installation by default which is included in Ubuntu installation description but not the WSL