### PR TITLE
Update processor_alpaca.py

### DIFF
--- a/finrl/meta/data_processors/processor_alpaca.py
+++ b/finrl/meta/data_processors/processor_alpaca.py
@@ -302,7 +302,7 @@ class AlpacaProcessor:
     def get_trading_days(self, start, end):
         nyse = tc.get_calendar("NYSE")
         df = nyse.sessions_in_range(
-            pd.Timestamp(start, tz=pytz.UTC), pd.Timestamp(end, tz=pytz.UTC)
+            pd.Timestamp(start).tz_localize(None), pd.Timestamp(end).tz_localize(None)
         )
         trading_days = []
         for day in df:


### PR DESCRIPTION
Fix for the below error, which occurs because calendar_helpers.py expects a timezone naive input:

---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-15-8d8a0892e428> in <cell line: 1>()
----> 1 data = DP.clean_data(data)
      2 data = DP.add_technical_indicator(data, INDICATORS)
      3 data = DP.add_vix(data)

6 frames
/usr/local/lib/python3.10/site-packages/finrl/meta/data_processor.py in clean_data(self, df)
     44 
     45     def clean_data(self, df) -> pd.DataFrame:
---> 46         df = self.processor.clean_data(df)
     47 
     48         return df

/usr/local/lib/python3.10/site-packages/finrl/meta/data_processors/processor_alpaca.py in clean_data(self, df)
     79                 df = df[df.timestamp != time]
     80 
---> 81         trading_days = self.get_trading_days(start=self.start, end=self.end)
     82         # produce full timestamp index
     83         times = []

/usr/local/lib/python3.10/site-packages/finrl/meta/data_processors/processor_alpaca.py in get_trading_days(self, start, end)
    302     def get_trading_days(self, start, end):
    303         nyse = tc.get_calendar("NYSE")
--> 304         df = nyse.sessions_in_range(
    305             pd.Timestamp(start, tz=pytz.UTC), pd.Timestamp(end, tz=pytz.UTC)
    306         )

/usr/local/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py in sessions_in_range(self, start, end, _parse)
   2197             Sessions from `start` through `end`.
   2198         """
-> 2199         slc = self._get_sessions_slice(start, end, _parse)
   2200         return self.sessions[slc]
   2201 

/usr/local/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py in _get_sessions_slice(self, start, end, _parse)
   2174     def _get_sessions_slice(self, start: Date, end: Date, _parse=True) -> slice:
   2175         """Slice representing a range of sessions."""
-> 2176         start, end = self._parse_start_end_dates(start, end, _parse)
   2177         slice_start = self.sessions_nanos.searchsorted(start.value, side="left")
   2178         slice_end = self.sessions_nanos.searchsorted(end.value, side="right")

/usr/local/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py in _parse_start_end_dates(self, start, end, _parse)
   2170         if not _parse:
   2171             return start, end
-> 2172         return parse_date(start, "start", self), parse_date(end, "end", self)
   2173 
   2174     def _get_sessions_slice(self, start: Date, end: Date, _parse=True) -> slice:

/usr/local/lib/python3.10/site-packages/exchange_calendars/calendar_helpers.py in parse_date(date, param_name, calendar, raise_oob)
    376 
    377     if ts.tz is not None:
--> 378         raise ValueError(
    379             f"Parameter `{param_name}` received with timezone defined as '{ts.tz.zone}'"
    380             f" although a Date must be timezone naive."

ValueError: Parameter `start` received with timezone defined as 'UTC' although a Date must be timezone naive.