### PR TITLE
typo and python version

### DIFF
--- a/docs/source/start/installation.rst
+++ b/docs/source/start/installation.rst
@@ -142,8 +142,8 @@ Windows 10
 ======================
 Prepare for install
 --------------------------------------------------------------------------
-1. VPN is needed if using YahooFinance in china (pyfolio, elegantRL pip dependencies need pull code, YahooFinance has stopped the service in china). Othewise, please ignore it.
-2. python version >=3.7
+1. VPN is needed if using YahooFinance in china (pyfolio, elegantRL pip dependencies need pull code, YahooFinance has stopped the service in china). Otherwise, please ignore it.
+2. python version >=3.7 and python version < 3.11
 3. pip remove zipline, if your system has installed zipline, zipline has conflicts with the FinRL.
 
 Step 1: Clone `FinRL <https://github.com/AI4Finance-Foundation/FinRL>`_


### PR DESCRIPTION
Hello,
I just corrected a typo.
And also it doesn't seem possible to install finRL with python >= 3.11 yet. I just tried and I got : 

> ERROR: Package 'finrl' requires a different Python: 3.11.4 not in '<3.11,>=3.10'