### PR TITLE
Fixing tuple, and 'UTC has no key' errors in examples/FinRL_PaperTrading_Demo.ipynb

### DIFF
--- a/examples/FinRL_PaperTrading_Demo.ipynb
+++ b/examples/FinRL_PaperTrading_Demo.ipynb
@@ -317,9 +317,9 @@
     "            action, logprob = [t.squeeze(0) for t in get_action(state.unsqueeze(0))[:2]]\n",
     "\n",
     "            ary_action = convert(action).detach().cpu().numpy()\n",
-    "            ary_state, reward, done, _ = env.step(ary_action)\n",
+    "            ary_state, reward, done, _, _ = env.step(ary_action)\n",
     "            if done:\n",
-    "                ary_state = env.reset()\n",
+    "                ary_state, _ = env.reset()\n",
     "\n",
     "            states[i] = state\n",
     "            actions[i] = action\n",
@@ -411,11 +411,12 @@
     "        self.if_discrete = False  # discrete action or continuous action\n",
     "\n",
     "    def reset(self) -> np.ndarray:  # reset the agent in env\n",
-    "        return self.env.reset()\n",
+    "        resetted_env, _ = self.env.reset()\n",
+    "        return resetted_env\n",
     "\n",
     "    def step(self, action: np.ndarray) -> (np.ndarray, float, bool, dict):  # agent interacts in env\n",
     "        # We suggest that adjust action space to (-1, +1) when designing a custom env.\n",
-    "        state, reward, done, info_dict = self.env.step(action * 2)\n",
+    "        state, reward, done, info_dict, _ = self.env.step(action * 2)\n",
     "        return state.reshape(self.state_dim), float(reward), done, info_dict\n",
     "\n",
     "    \n",
@@ -424,7 +425,9 @@
     "\n",
     "    env = build_env(args.env_class, args.env_args)\n",
     "    agent = args.agent_class(args.net_dims, args.state_dim, args.action_dim, gpu_id=args.gpu_id, args=args)\n",
-    "    agent.states = env.reset()[np.newaxis, :]\n",
+    "\n",
+    "    new_env, _ = env.reset()\n",
+    "    agent.states = new_env[np.newaxis, :]\n",
     "\n",
     "    evaluator = Evaluator(eval_env=build_env(args.env_class, args.env_args),\n",
     "                          eval_per_step=args.eval_per_step,\n",
@@ -502,14 +505,14 @@
     "def get_rewards_and_steps(env, actor, if_render: bool = False) -> (float, int):  # cumulative_rewards and episode_steps\n",
     "    device = next(actor.parameters()).device  # net.parameters() is a Python generator.\n",
     "\n",
-    "    state = env.reset()\n",
+    "    state, _ = env.reset()\n",
     "    episode_steps = 0\n",
     "    cumulative_returns = 0.0  # sum of rewards in an episode\n",
     "    for episode_steps in range(12345):\n",
     "        tensor_state = torch.as_tensor(state, dtype=torch.float32, device=device).unsqueeze(0)\n",
     "        tensor_action = actor(tensor_state)\n",
     "        action = tensor_action.detach().cpu().numpy()[0]  # not need detach(), because using torch.no_grad() outside\n",
-    "        state, reward, done, _ = env.step(action)\n",
+    "        state, reward, done, _, _ = env.step(action)\n",
     "        cumulative_returns += reward\n",
     "\n",
     "        if if_render:\n",
@@ -525,7 +528,7 @@
     "id": "9tzAw9k26nAC"
    },
    "source": [
-    "##DRL Agent Class"
+    "## DRL Agent Class"
    ]
   },
   {
@@ -634,7 +637,7 @@
     "\n",
     "        # test on the testing env\n",
     "        _torch = torch\n",
-    "        state = environment.reset()\n",
+    "        state, _ = environment.reset()\n",
     "        episode_returns = []  # the cumulative_return / initial_account\n",
     "        episode_total_assets = [environment.initial_total_asset]\n",
     "        with _torch.no_grad():\n",
@@ -644,7 +647,7 @@
     "                action = (\n",
     "                    a_tensor.detach().cpu().numpy()[0]\n",
     "                )  # not need detach(), because with torch.no_grad() outside\n",
-    "                state, reward, done, _ = environment.step(action)\n",
+    "                state, reward, done, _, _ = environment.step(action)\n",
     "\n",
     "                total_asset = (\n",
     "                    environment.amount\n",
@@ -1693,8 +1696,8 @@
    "source": [
     "def get_trading_days(start, end):\n",
     "    nyse = tc.get_calendar('NYSE')\n",
-    "    df = nyse.sessions_in_range(pd.Timestamp(start,tz=pytz.UTC),\n",
-    "                                pd.Timestamp(end,tz=pytz.UTC))\n",
+    "    df = nyse.sessions_in_range(pd.Timestamp(start),\n",
+    "                                pd.Timestamp(end))\n",
     "    trading_days = []\n",
     "    for day in df:\n",
     "        trading_days.append(str(day)[:10])\n",
@@ -1889,7 +1892,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.11"
   },
   "vscode": {
    "interpreter": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ swig
 
 tensorboardX
 wheel>=0.33.6
+wrds
 
 # market data & paper trading API
 yfinance
-wrds


### PR DESCRIPTION
I have submitted a similar pull request at [FinRL-Tutorials](https://github.com/AI4Finance-Foundation/FinRL-Tutorials). Still, I think it should also be updated here since more people might come here to view the `example` files, and are unaware of the tutorial repository.

---

An updated version of the `gymnasium` package changes the behavior of `gymnasium.Env.reset`. The return value of the reset method now returns a tuple of observation and info, which causes the tuple error mentioned in #1184 and #1164. Please refer to the [gymasium's documentation](https://gymnasium.farama.org/api/env/#gymnasium.Env.reset:~:text=Changed%20in%20version%20v0.25%3A%20The%20return_info%20parameter%20was%20removed%20and%20now%20info%20is%20expected%20to%20be%20returned.) for more details. This is fixed by ignoring the second value in the returned tuple.

The current version of the exchange-calendars package requires the dates to be timezone native, which causes the "UTC has no key" error. The traceback can be found below. This was resolved by erasing tz=pytz.UTC.
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[5], [line 1](vscode-notebook-cell:?execution_count=5&line=1)
----> [1](vscode-notebook-cell:?execution_count=5&line=1) df_erl, cumu_erl = alpaca_history(key=API_KEY, 
      [2](vscode-notebook-cell:?execution_count=5&line=2)                                   secret=API_SECRET, 
      [3](vscode-notebook-cell:?execution_count=5&line=3)                                   url=API_BASE_URL, 
      [4](vscode-notebook-cell:?execution_count=5&line=4)                                   start='2024-03-01', #must be within 1 month
      [5](vscode-notebook-cell:?execution_count=5&line=5)                                   end='2024-03-16') #change the date if error occurs

Cell In[4], [line 13](vscode-notebook-cell:?execution_count=4&line=13)
     [11](vscode-notebook-cell:?execution_count=4&line=11) def alpaca_history(key, secret, url, start, end):
     [12](vscode-notebook-cell:?execution_count=4&line=12)     api = tradeapi.REST(key, secret, url, 'v2')
---> [13](vscode-notebook-cell:?execution_count=4&line=13)     trading_days = get_trading_days(start, end)
     [14](vscode-notebook-cell:?execution_count=4&line=14)     df = pd.DataFrame()
     [15](vscode-notebook-cell:?execution_count=4&line=15)     for day in trading_days:
     [16](vscode-notebook-cell:?execution_count=4&line=16)         #df = df.append(api.get_portfolio_history(date_start = day,timeframe='5Min').df.iloc[:78])

Cell In[4], [line 3](vscode-notebook-cell:?execution_count=4&line=3)
      [1](vscode-notebook-cell:?execution_count=4&line=1) def get_trading_days(start, end):
      [2](vscode-notebook-cell:?execution_count=4&line=2)     nyse = tc.get_calendar('NYSE')
----> [3](vscode-notebook-cell:?execution_count=4&line=3)     df = nyse.sessions_in_range(pd.Timestamp(start,tz=pytz.UTC),
      [4](vscode-notebook-cell:?execution_count=4&line=4)                                 pd.Timestamp(end,tz=pytz.UTC))
      [5](vscode-notebook-cell:?execution_count=4&line=5)     trading_days = []
      [6](vscode-notebook-cell:?execution_count=4&line=6)     for day in df:

File [~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2200](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2200), in ExchangeCalendar.sessions_in_range(self, start, end, _parse)
   [2182](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2182) def sessions_in_range(
   [2183](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2183)     self, start: Date, end: Date, _parse: bool = True
   [2184](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2184) ) -> pd.DatetimeIndex:
   [2185](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2185)     """Return sessions within a given range.
   [2186](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2186) 
   [2187](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2187)     Parameters
   (...)
   [2198](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2198)         Sessions from `start` through `end`.
   [2199](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2199)     """
-> [2200](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2200)     slc = self._get_sessions_slice(start, end, _parse)
   [2201](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2201)     return self.sessions[slc]

File [~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2177](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2177), in ExchangeCalendar._get_sessions_slice(self, start, end, _parse)
   [2175](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2175) def _get_sessions_slice(self, start: Date, end: Date, _parse=True) -> slice:
   [2176](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2176)     """Slice representing a range of sessions."""
-> [2177](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2177)     start, end = self._parse_start_end_dates(start, end, _parse)
   [2178](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2178)     slice_start = self.sessions_nanos.searchsorted(start.value, side="left")
   [2179](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2179)     slice_end = self.sessions_nanos.searchsorted(end.value, side="right")

File [~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2173](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2173), in ExchangeCalendar._parse_start_end_dates(self, start, end, _parse)
   [2171](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2171) if not _parse:
   [2172](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2172)     return start, end
-> [2173](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/exchange_calendar.py:2173) return parse_date(start, "start", self), parse_date(end, "end", self)

File [~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/calendar_helpers.py:379](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/calendar_helpers.py:379), in parse_date(date, param_name, calendar, raise_oob)
    [375](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/calendar_helpers.py:375) ts = parse_timestamp(date, param_name, raise_oob=False, side="left", utc=False)
    [377](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/calendar_helpers.py:377) if ts.tz is not None:
    [378](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/calendar_helpers.py:378)     raise ValueError(
--> [379](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/calendar_helpers.py:379)         f"Parameter `{param_name}` received with timezone defined as '{ts.tz.key}'"
    [380](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/calendar_helpers.py:380)         f" although a Date must be timezone naive."
    [381](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/calendar_helpers.py:381)     )
    [383](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/calendar_helpers.py:383) if not ts == ts.normalize():
    [384](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/calendar_helpers.py:384)     raise ValueError(
    [385](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/calendar_helpers.py:385)         f"Parameter `{param_name}` parsed as '{ts}' although a Date must have"
    [386](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/calendar_helpers.py:386)         f" a time component of 00:00."
    [387](https://vscode-remote+wsl-002bubuntu.vscode-resource.vscode-cdn.net/home/kurone02/FinRL/examples/~/miniconda3/envs/trading/lib/python3.10/site-packages/exchange_calendars/calendar_helpers.py:387)     )

AttributeError: 'UTC' object has no attribute 'key'
```