### PR TITLE
fix: Moved device parameter from DRLAgent initialization to get_model…

### DIFF
--- a/finrl/agents/stablebaselines3/models.py
+++ b/finrl/agents/stablebaselines3/models.py
@@ -85,6 +85,7 @@ class DRLAgent:
         verbose=1,
         seed=None,
         tensorboard_log=None,
+        device="cpu"  # 添加device参数，默认为cpu
     ):
         if model_name not in MODELS:
             raise ValueError(
@@ -107,6 +108,7 @@ class DRLAgent:
             verbose=verbose,
             policy_kwargs=policy_kwargs,
             seed=seed,
+            device=device,  # 传递device参数
             **model_kwargs,
         )
 
@@ -196,6 +198,7 @@ class DRLEnsembleAgent:
         model_kwargs=None,
         seed=None,
         verbose=1,
+        device="cpu"  # 添加device参数，默认为cpu
     ):
         if model_name not in MODELS:
             raise ValueError(
@@ -220,6 +223,7 @@ class DRLEnsembleAgent:
             verbose=verbose,
             policy_kwargs=policy_kwargs,
             seed=seed,
+            device=device,  # 传递device参数
             **temp_model_kwargs,
         )
 

--- a/finrl/agents/stablebaselines3/models.py
+++ b/finrl/agents/stablebaselines3/models.py
@@ -85,7 +85,7 @@ class DRLAgent:
         verbose=1,
         seed=None,
         tensorboard_log=None,
-        device="cpu"  # 添加device参数，默认为cpu
+        device="cpu",  # 添加device参数，默认为cpu
     ):
         if model_name not in MODELS:
             raise ValueError(
@@ -198,7 +198,7 @@ class DRLEnsembleAgent:
         model_kwargs=None,
         seed=None,
         verbose=1,
-        device="cpu"  # 添加device参数，默认为cpu
+        device="cpu",  # 添加device参数，默认为cpu
     ):
         if model_name not in MODELS:
             raise ValueError(


### PR DESCRIPTION
fix: Moved device parameter from DRLAgent initialization to get_model method

- Removed the incorrect use of `device` in the `DRLAgent` constructor, as `device` is not a valid parameter for initialization.
- Added `device` parameter correctly to the `get_model` method, allowing models to be trained on GPU (using `cuda`) or CPU as specified during model creation.
- Ensured the model uses the appropriate device when calling `get_model`.
