### PR TITLE
Fix Multi-Level Column Names in DataFrame Downloaded using YahooDownloader

### DIFF
--- a/finrl/meta/preprocessor/yahoodownloader.py
+++ b/finrl/meta/preprocessor/yahoodownloader.py
@@ -51,6 +51,8 @@ class YahooDownloader:
             temp_df = yf.download(
                 tic, start=self.start_date, end=self.end_date, proxy=proxy
             )
+            if temp_df.columns.nlevels != 1:
+                temp_df.columns = temp_df.columns.droplevel(1)
             temp_df["tic"] = tic
             if len(temp_df) > 0:
                 # data_df = data_df.append(temp_df)


### PR DESCRIPTION
Fixes https://github.com/AI4Finance-Foundation/FinRL/issues/1286

This pull request addresses an issue in yahoodownloader.py where the DataFrame downloaded from Yahoo contains multi-level column names, even though a single-level column structure is expected.