### PR TITLE
Fix Multi-Level Column Names in DataFrame Downloaded using processor_yahoofinance.

### DIFF
--- a/finrl/meta/data_processors/processor_yahoofinance.py
+++ b/finrl/meta/data_processors/processor_yahoofinance.py
@@ -110,6 +110,9 @@ class YahooFinanceProcessor:
                     interval=self.time_interval,
                     proxy=proxy,
                 )
+                if temp_df.columns.nlevels != 1:
+                    temp_df.columns = temp_df.columns.droplevel(1)
+
                 temp_df["tic"] = tic
                 data_df = pd.concat([data_df, temp_df])
                 current_tic_start_date += delta


### PR DESCRIPTION
Referring to #1290 , the same issue exists in processor_yahoofinance. After adding it, it works properly.