### PR TITLE
Update renaming of columns from yfinance and passing auto_adjust as optional parameter

### DIFF
--- a/finrl/meta/preprocessor/yahoodownloader.py
+++ b/finrl/meta/preprocessor/yahoodownloader.py
@@ -33,7 +33,7 @@ class YahooDownloader:
         self.end_date = end_date
         self.ticker_list = ticker_list
 
-    def fetch_data(self, proxy=None) -> pd.DataFrame:
+    def fetch_data(self, proxy=None, auto_adjust=False) -> pd.DataFrame:
         """Fetches data from Yahoo API
         Parameters
         ----------
@@ -49,7 +49,7 @@ class YahooDownloader:
         num_failures = 0
         for tic in self.ticker_list:
             temp_df = yf.download(
-                tic, start=self.start_date, end=self.end_date, proxy=proxy
+                tic, start=self.start_date, end=self.end_date, proxy=proxy, auto_adjust=auto_adjust
             )
             if temp_df.columns.nlevels != 1:
                 temp_df.columns = temp_df.columns.droplevel(1)
@@ -65,16 +65,15 @@ class YahooDownloader:
         data_df = data_df.reset_index()
         try:
             # convert the column names to standardized names
-            data_df.columns = [
-                "date",
-                "open",
-                "high",
-                "low",
-                "close",
-                "adjcp",
-                "volume",
-                "tic",
-            ]
+            data_df.rename(columns={"Date": "date", 
+                        "Adj Close": "adjcp",
+                        "Close": "close",
+                        "High": "high", 
+                        "Low": "low", 
+                        "Volume": "volumne", 
+                        "Open": "open",
+                        "tic":"tic"}, inplace=True)
+            
             # use adjusted close price instead of close price
             data_df["close"] = data_df["adjcp"]
             # drop the adjusted close price column

--- a/finrl/meta/preprocessor/yahoodownloader.py
+++ b/finrl/meta/preprocessor/yahoodownloader.py
@@ -49,7 +49,11 @@ class YahooDownloader:
         num_failures = 0
         for tic in self.ticker_list:
             temp_df = yf.download(
-                tic, start=self.start_date, end=self.end_date, proxy=proxy, auto_adjust=auto_adjust
+                tic,
+                start=self.start_date,
+                end=self.end_date,
+                proxy=proxy,
+                auto_adjust=auto_adjust,
             )
             if temp_df.columns.nlevels != 1:
                 temp_df.columns = temp_df.columns.droplevel(1)
@@ -65,15 +69,20 @@ class YahooDownloader:
         data_df = data_df.reset_index()
         try:
             # convert the column names to standardized names
-            data_df.rename(columns={"Date": "date", 
-                        "Adj Close": "adjcp",
-                        "Close": "close",
-                        "High": "high", 
-                        "Low": "low", 
-                        "Volume": "volumne", 
-                        "Open": "open",
-                        "tic":"tic"}, inplace=True)
-            
+            data_df.rename(
+                columns={
+                    "Date": "date",
+                    "Adj Close": "adjcp",
+                    "Close": "close",
+                    "High": "high",
+                    "Low": "low",
+                    "Volume": "volumne",
+                    "Open": "open",
+                    "tic": "tic",
+                },
+                inplace=True,
+            )
+
             # use adjusted close price instead of close price
             data_df["close"] = data_df["adjcp"]
             # drop the adjusted close price column

--- a/finrl/meta/preprocessor/yahoodownloader.py
+++ b/finrl/meta/preprocessor/yahoodownloader.py
@@ -76,7 +76,7 @@ class YahooDownloader:
                     "Close": "close",
                     "High": "high",
                     "Low": "low",
-                    "Volume": "volumne",
+                    "Volume": "volume",
                     "Open": "open",
                     "tic": "tic",
                 },


### PR DESCRIPTION
The yFinance library only passes the Adj Close when auto_adjust is set to False. This pull request was created to address Issue #1300 by passing that parameter along with changing how the Pandas Dataframe renames the columns. 