### PR TITLE
Add support up to Python 3.11 for FinRL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ stable-baselines3 = {version = ">=2.0.0a5", extras = ["extra"]}
 stockstats = "^0.5"
 wrds = "^3"
 yfinance = "^0.2"
-alpaca-py = ">=0.37"
+alpaca-py = "^0.37"
 webdriver-manager = "^4"
 selenium = "^4"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ stable-baselines3 = {version = ">=2.0.0a5", extras = ["extra"]}
 stockstats = "^0.5"
 wrds = "^3"
 yfinance = "^0.2"
+alpaca-py = "^0.37"
+webdriver-manager = "^4"
+selenium = "^4"
+
 
 [tool.poetry.group.dev.dependencies]
 black = "^24"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ stable-baselines3 = {version = ">=2.0.0a5", extras = ["extra"]}
 stockstats = "^0.5"
 wrds = "^3"
 yfinance = "^0.2"
-alpaca-py = "^0.37"
+alpaca-py = ">=0.37"
 webdriver-manager = "^4"
 selenium = "^4"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ github = "https://github.com/finrl/finrl-library"
 [tool.poetry.dependencies]
 python = "~3.11"
 elegantrl = {git="https://github.com/AI4Finance-Foundation/ElegantRL.git#egg=elegantrl"}
-alpaca-trade-api = "^3"
 ccxt = "^3"
 exchange-calendars = "^4"
 jqdatasdk = "^1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ keywords=["Reinforcement Learning", "Finance"]
 github = "https://github.com/finrl/finrl-library"
 
 [tool.poetry.dependencies]
-python = "~3.10"
+python = "~3.11"
 elegantrl = {git="https://github.com/AI4Finance-Foundation/ElegantRL.git#egg=elegantrl"}
 alpaca-trade-api = "^3"
 ccxt = "^3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers=[
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ github = "https://github.com/finrl/finrl-library"
 [tool.poetry.dependencies]
 python = "~3.11"
 elegantrl = {git="https://github.com/AI4Finance-Foundation/ElegantRL.git#egg=elegantrl"}
+alpaca-trade-api = "^3"
 ccxt = "^3"
 exchange-calendars = "^4"
 jqdatasdk = "^1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 alpaca_trade_api>=2.1.0
+alpaca-py
 ccxt>=1.66.32  # make sure that >=1.66.32
 elegantrl
 exchange_calendars==3.6.3 # because raise exception with 4.1.1, success tested with 3.6.3
@@ -35,7 +36,8 @@ setuptools>=65.5.0
 sphinx
 sphinx_rtd_theme
 
-
+selenium
+webdriver-manager
 SQLAlchemy
 stable-baselines3[extra]
 stockstats>=0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-alpaca_trade_api>=2.1.0
 alpaca-py
+alpaca_trade_api>=2.1.0
 ccxt>=1.66.32  # make sure that >=1.66.32
 elegantrl
 exchange_calendars==3.6.3 # because raise exception with 4.1.1, success tested with 3.6.3
@@ -28,6 +28,8 @@ recommonmark
 # Model Building Requirements
 scikit-learn>=0.21.0
 
+selenium
+
 # packaging
 #setuptools>=41.4.0
 setuptools>=65.5.0
@@ -35,15 +37,13 @@ setuptools>=65.5.0
 # to build docs using sphinx
 sphinx
 sphinx_rtd_theme
-
-selenium
-webdriver-manager
 SQLAlchemy
 stable-baselines3[extra]
 stockstats>=0.4.0
 swig
 
 tensorboardX
+webdriver-manager
 wheel>=0.33.6
 wrds
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],


### PR DESCRIPTION
#1313 

Currently, the pyproject.toml does not allow FinRL to be used in environments where the Python version exceeds 3.10. This change allows for FinRL to be installed in environments that use 3.11, like Google Colab [(Google Colab Blog Post)](https://medium.com/google-colab/colab-updated-to-python-3-11-00197d6172b1).

Please let me know if other items, such as unit tests, documentation, and build processes, need to be updated due to this change.