### PR TITLE
Replace pyfolio with pyfolio-reloaded

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ elegantrl = {git="https://github.com/AI4Finance-Foundation/ElegantRL.git#egg=ele
 alpaca-trade-api = "^3"
 ccxt = "^3"
 jqdatasdk = "^1"
-pyfolio = "^0.9"
+pyfolio-reloaded = "^0.9"
 pyportfolioopt = "^1"
 ray = {extras=["default", "tune"], version = "^2"}
 scikit-learn = "^1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ pandas_market_calendars  # calendars
 
 #hooks
 pre-commit
-pyfolio
 pyfolio-reloaded
 
 # testing requirements


### PR DESCRIPTION
This is the issue that keeps FinRL from building in Python 3.12.  pyfolio library is so old it is using functions that are deprecated in Python 3.12, specifically SafeConfigParser.