### PR TITLE
Allow for custom callbacks to be passed to train_model

### DIFF
--- a/finrl/agents/stablebaselines3/models.py
+++ b/finrl/agents/stablebaselines3/models.py
@@ -54,6 +54,20 @@ class TensorboardCallback(BaseCallback):
                 print("Inner Error:", inner_error)
         return True
 
+   def _on_rollout_end(self) -> bool:
+        try:
+            rollout_buffer_rewards = self.locals['rollout_buffer'].rewards.flatten()
+            self.logger.record(key="train/reward_min", value=min(rollout_buffer_rewards))
+            self.logger.record(key="train/reward_mean", value=statistics.mean(rollout_buffer_rewards))
+            self.logger.record(key="train/reward_max", value=max(rollout_buffer_rewards))
+        except BaseException as error:
+            # Handle the case where "rewards" is not found
+            self.logger.record(key="train/reward_min", value=None)
+            self.logger.record(key="train/reward_mean", value=None)
+            self.logger.record(key="train/reward_max", value=None)
+            print("Logging Error:", error)
+        return True
+
 
 class DRLAgent:
     """Provides implementations for DRL algorithms

--- a/finrl/agents/stablebaselines3/models.py
+++ b/finrl/agents/stablebaselines3/models.py
@@ -54,7 +54,7 @@ class TensorboardCallback(BaseCallback):
                 print("Inner Error:", inner_error)
         return True
 
-   def _on_rollout_end(self) -> bool:
+    def _on_rollout_end(self) -> bool:
         try:
             rollout_buffer_rewards = self.locals['rollout_buffer'].rewards.flatten()
             self.logger.record(key="train/reward_min", value=min(rollout_buffer_rewards))

--- a/finrl/agents/stablebaselines3/models.py
+++ b/finrl/agents/stablebaselines3/models.py
@@ -10,7 +10,7 @@ from stable_baselines3 import DDPG
 from stable_baselines3 import PPO
 from stable_baselines3 import SAC
 from stable_baselines3 import TD3
-from stable_baselines3.common.callbacks import BaseCallback
+from stable_baselines3.common.callbacks import BaseCallback, CallbackList
 from stable_baselines3.common.noise import NormalActionNoise
 from stable_baselines3.common.noise import OrnsteinUhlenbeckActionNoise
 from stable_baselines3.common.type_aliases import MaybeCallback
@@ -119,7 +119,7 @@ class DRLAgent:
             total_timesteps=total_timesteps,
             tb_log_name=tb_log_name,
             callback=(
-                [TensorboardCallback(), callback]
+                CallbackList([TensorboardCallback(), callback])
                 if callback is not None
                 else TensorboardCallback()
             ),
@@ -241,7 +241,7 @@ class DRLEnsembleAgent:
             total_timesteps=total_timesteps,
             tb_log_name=tb_log_name,
             callback=(
-                [TensorboardCallback(), callback]
+                CallbackList([TensorboardCallback(), callback])
                 if callback is not None
                 else TensorboardCallback()
             ),

--- a/finrl/agents/stablebaselines3/models.py
+++ b/finrl/agents/stablebaselines3/models.py
@@ -122,7 +122,9 @@ class DRLAgent:
             total_timesteps=total_timesteps,
             tb_log_name=tb_log_name,
             callback=(
-                CallbackList([TensorboardCallback()] + [callback for callback in callbacks])
+                CallbackList(
+                    [TensorboardCallback()] + [callback for callback in callbacks]
+                )
                 if callbacks is not None
                 else TensorboardCallback()
             ),
@@ -244,7 +246,9 @@ class DRLEnsembleAgent:
             total_timesteps=total_timesteps,
             tb_log_name=tb_log_name,
             callback=(
-                CallbackList([TensorboardCallback()] + [callback for callback in callbacks])
+                CallbackList(
+                    [TensorboardCallback()] + [callback for callback in callbacks]
+                )
                 if callbacks is not None
                 else TensorboardCallback()
             ),

--- a/finrl/agents/stablebaselines3/models.py
+++ b/finrl/agents/stablebaselines3/models.py
@@ -14,7 +14,6 @@ from stable_baselines3.common.callbacks import BaseCallback
 from stable_baselines3.common.callbacks import CallbackList
 from stable_baselines3.common.noise import NormalActionNoise
 from stable_baselines3.common.noise import OrnsteinUhlenbeckActionNoise
-from stable_baselines3.common.type_aliases import MaybeCallback
 from stable_baselines3.common.vec_env import DummyVecEnv
 
 from finrl import config
@@ -114,14 +113,17 @@ class DRLAgent:
 
     @staticmethod
     def train_model(
-        model, tb_log_name, total_timesteps=5000, callback: MaybeCallback = None
+        model,
+        tb_log_name,
+        total_timesteps=5000,
+        callbacks: Type[BaseCallback] = None,
     ):  # this function is static method, so it can be called without creating an instance of the class
         model = model.learn(
             total_timesteps=total_timesteps,
             tb_log_name=tb_log_name,
             callback=(
-                CallbackList([TensorboardCallback(), callback])
-                if callback is not None
+                CallbackList([TensorboardCallback()] + [callback for callback in callbacks])
+                if callbacks is not None
                 else TensorboardCallback()
             ),
         )
@@ -236,14 +238,14 @@ class DRLEnsembleAgent:
         tb_log_name,
         iter_num,
         total_timesteps=5000,
-        callback: MaybeCallback = None,
+        callbacks: Type[BaseCallback] = None,
     ):
         model = model.learn(
             total_timesteps=total_timesteps,
             tb_log_name=tb_log_name,
             callback=(
-                CallbackList([TensorboardCallback(), callback])
-                if callback is not None
+                CallbackList([TensorboardCallback()] + [callback for callback in callbacks])
+                if callbacks is not None
                 else TensorboardCallback()
             ),
         )

--- a/finrl/agents/stablebaselines3/models.py
+++ b/finrl/agents/stablebaselines3/models.py
@@ -11,9 +11,9 @@ from stable_baselines3 import PPO
 from stable_baselines3 import SAC
 from stable_baselines3 import TD3
 from stable_baselines3.common.callbacks import BaseCallback
-from stable_baselines3.common.type_aliases import MaybeCallback
 from stable_baselines3.common.noise import NormalActionNoise
 from stable_baselines3.common.noise import OrnsteinUhlenbeckActionNoise
+from stable_baselines3.common.type_aliases import MaybeCallback
 from stable_baselines3.common.vec_env import DummyVecEnv
 
 from finrl import config
@@ -118,7 +118,11 @@ class DRLAgent:
         model = model.learn(
             total_timesteps=total_timesteps,
             tb_log_name=tb_log_name,
-            callback=[TensorboardCallback(), callback] if callback is not None else TensorboardCallback(),
+            callback=(
+                [TensorboardCallback(), callback]
+                if callback is not None
+                else TensorboardCallback()
+            ),
         )
         return model
 
@@ -225,11 +229,22 @@ class DRLEnsembleAgent:
         )
 
     @staticmethod
-    def train_model(model, model_name, tb_log_name, iter_num, total_timesteps=5000, callback: MaybeCallback = None):
+    def train_model(
+        model,
+        model_name,
+        tb_log_name,
+        iter_num,
+        total_timesteps=5000,
+        callback: MaybeCallback = None,
+    ):
         model = model.learn(
             total_timesteps=total_timesteps,
             tb_log_name=tb_log_name,
-            callback=[TensorboardCallback(), callback] if callback is not None else TensorboardCallback(),
+            callback=(
+                [TensorboardCallback(), callback]
+                if callback is not None
+                else TensorboardCallback()
+            ),
         )
         model.save(
             f"{config.TRAINED_MODEL_DIR}/{model_name.upper()}_{total_timesteps // 1000}k_{iter_num}"

--- a/finrl/agents/stablebaselines3/models.py
+++ b/finrl/agents/stablebaselines3/models.py
@@ -11,6 +11,7 @@ from stable_baselines3 import PPO
 from stable_baselines3 import SAC
 from stable_baselines3 import TD3
 from stable_baselines3.common.callbacks import BaseCallback
+from stable_baselines3.common.type_aliases import MaybeCallback
 from stable_baselines3.common.noise import NormalActionNoise
 from stable_baselines3.common.noise import OrnsteinUhlenbeckActionNoise
 from stable_baselines3.common.vec_env import DummyVecEnv
@@ -112,12 +113,12 @@ class DRLAgent:
 
     @staticmethod
     def train_model(
-        model, tb_log_name, total_timesteps=5000
+        model, tb_log_name, total_timesteps=5000, callback: MaybeCallback = None
     ):  # this function is static method, so it can be called without creating an instance of the class
         model = model.learn(
             total_timesteps=total_timesteps,
             tb_log_name=tb_log_name,
-            callback=TensorboardCallback(),
+            callback=[TensorboardCallback(), callback] if callback is not None else TensorboardCallback(),
         )
         return model
 
@@ -224,11 +225,11 @@ class DRLEnsembleAgent:
         )
 
     @staticmethod
-    def train_model(model, model_name, tb_log_name, iter_num, total_timesteps=5000):
+    def train_model(model, model_name, tb_log_name, iter_num, total_timesteps=5000, callback: MaybeCallback = None):
         model = model.learn(
             total_timesteps=total_timesteps,
             tb_log_name=tb_log_name,
-            callback=TensorboardCallback(),
+            callback=[TensorboardCallback(), callback] if callback is not None else TensorboardCallback(),
         )
         model.save(
             f"{config.TRAINED_MODEL_DIR}/{model_name.upper()}_{total_timesteps // 1000}k_{iter_num}"

--- a/finrl/agents/stablebaselines3/models.py
+++ b/finrl/agents/stablebaselines3/models.py
@@ -10,7 +10,8 @@ from stable_baselines3 import DDPG
 from stable_baselines3 import PPO
 from stable_baselines3 import SAC
 from stable_baselines3 import TD3
-from stable_baselines3.common.callbacks import BaseCallback, CallbackList
+from stable_baselines3.common.callbacks import BaseCallback
+from stable_baselines3.common.callbacks import CallbackList
 from stable_baselines3.common.noise import NormalActionNoise
 from stable_baselines3.common.noise import OrnsteinUhlenbeckActionNoise
 from stable_baselines3.common.type_aliases import MaybeCallback

--- a/finrl/agents/stablebaselines3/models.py
+++ b/finrl/agents/stablebaselines3/models.py
@@ -56,10 +56,16 @@ class TensorboardCallback(BaseCallback):
 
     def _on_rollout_end(self) -> bool:
         try:
-            rollout_buffer_rewards = self.locals['rollout_buffer'].rewards.flatten()
-            self.logger.record(key="train/reward_min", value=min(rollout_buffer_rewards))
-            self.logger.record(key="train/reward_mean", value=statistics.mean(rollout_buffer_rewards))
-            self.logger.record(key="train/reward_max", value=max(rollout_buffer_rewards))
+            rollout_buffer_rewards = self.locals["rollout_buffer"].rewards.flatten()
+            self.logger.record(
+                key="train/reward_min", value=min(rollout_buffer_rewards)
+            )
+            self.logger.record(
+                key="train/reward_mean", value=statistics.mean(rollout_buffer_rewards)
+            )
+            self.logger.record(
+                key="train/reward_max", value=max(rollout_buffer_rewards)
+            )
         except BaseException as error:
             # Handle the case where "rewards" is not found
             self.logger.record(key="train/reward_min", value=None)


### PR DESCRIPTION
For example:
```
from stable_baselines3.common.callbacks import EvalCallback
[...]
eval_callback = EvalCallback(
    env_backtest,
    best_model_save_path=os.path.join(TRAINED_MODEL_DIR, model_name),
    eval_freq=1,
    deterministic=True,
    render=False,
    warn=False,
)
[...]
trained_a2c = agent.train_model(model=model_a2c, tb_log_name='a2c', total_timesteps=TIMESTEPS, callback=eval_callback)
```

This mantains the default TensorboardCallback(), and adds further ones if specified.