### PR TITLE
Add Pandas Market Calendars to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ yfinance = "^0.2"
 alpaca-py = "^0.37"
 webdriver-manager = "^4"
 selenium = "^4"
+pandas-market-calendars = "^5"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
During the installation of FinRL, Pandas Market Calendars is not being installed. This changes adds it to pyproject.toml file and installs a version 5 or greater. 

Pandas Market Calendar 5.0+ requires python 3.9 at least.