### PR TITLE
Fix dependency conflict by updating importlib-metadata to >=6.0,<=8.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ elegantrl
 
 gputil
 gymnasium
-importlib-metadata==4.13.0
+importlib-metadata>=6.0,<=8.5.0
 jqdatasdk
 
 lz4


### PR DESCRIPTION
Title: Fix Dependency Conflict for importlib-metadata and opentelemetry-sdk

Description:

This pull request resolves a dependency conflict in requirements.txt that prevents successful installation of the project dependencies. The issue occurs because importlib-metadata==4.13.0 is incompatible with opentelemetry-api==1.30.0, which requires importlib-metadata>=6.0,<=8.5.0.

Changes Made:

Updated requirements.txt to change importlib-metadata==4.13.0 to importlib-metadata>=6.0,<=8.5.0.
Details:

Problem: When running pip install -r requirements.txt, the following error occurs:
ERROR: Cannot install importlib-metadata==4.13.0 and opentelemetry-sdk because these package versions have conflicting dependencies.
The conflict is caused by:
    The user requested importlib-metadata==4.13.0
    opentelemetry-api 1.30.0 depends on importlib-metadata<=8.5.0 and >=6.0
Solution: Modified requirements.txt to use a compatible version range for importlib-metadata.
Testing:
Tested on Windows 10 with Python 3.8 and pip 24.2 in a clean virtual environment.
Confirmed that pip install -r requirements.txt completes successfully.
Ran examples/Stock_NeurIPS2018.ipynb to verify that the project functionality is unaffected.
Additional Notes:

This change should be compatible with other dependencies in the project.
I tested the updated requirements.txt across multiple runs to ensure stability.
If further testing is needed (e.g., on Linux or macOS), or if a specific version like importlib-metadata==8.5.0 is preferred, I’m happy to make adjustments.
Thank you for reviewing this pull request! Please let me know if any changes or additional tests are required.