### PR TITLE
Fix env.reset() to return (obs, info) tuple for SB3 v2.0+ compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Key contributors include:
 
 - [**Hongyang (Bruce) Yang**](https://www.linkedin.com/in/brucehy/) – research and development on financial reinforcement learning frameworks, market environments, and quantitative trading applications
 - [other contributors…]
-  
+
 ## Overview
 
 FinRL has three layers: market environments, agents, and applications.  For a trading task (on the top), an agent (in the middle) interacts with a market environment (at the bottom), making sequential decisions.

--- a/finrl/meta/env_cryptocurrency_trading/env_btc_ccxt.py
+++ b/finrl/meta/env_cryptocurrency_trading/env_btc_ccxt.py
@@ -81,7 +81,7 @@ class BitcoinEnv:  # custom env
                 self.stocks * 2**-4,
             )
         ).astype(np.float32)
-        return state
+        return state, {}
 
     def step(self, action) -> (np.ndarray, float, bool, None):
         stock_action = action[0]

--- a/finrl/meta/env_cryptocurrency_trading/env_multiple_crypto.py
+++ b/finrl/meta/env_cryptocurrency_trading/env_multiple_crypto.py
@@ -60,7 +60,7 @@ class CryptoEnv:  # custom env
         self.total_asset = self.cash + (self.stocks * self.price_array[self.time]).sum()
 
         state = self.get_state()
-        return state
+        return state, {}
 
     def step(self, actions) -> (np.ndarray, float, bool, None):
         self.time += 1
@@ -106,7 +106,7 @@ class CryptoEnv:  # custom env
             tech_i = self.tech_array[self.time - i]
             normalized_tech_i = tech_i * 2**-15
             state = np.hstack((state, normalized_tech_i)).astype(np.float32)
-        return state
+        return state, {}
 
     def close(self):
         pass

--- a/finrl/meta/env_stock_trading/env_stocktrading_cashpenalty.py
+++ b/finrl/meta/env_stock_trading/env_stocktrading_cashpenalty.py
@@ -160,7 +160,7 @@ class StockTradingEnvCashpenalty(gym.Env):
             + self.get_date_vector(self.date_index)
         )
         self.state_memory.append(init_state)
-        return init_state
+        return init_state, {}
 
     def get_date_vector(self, date, cols=None):
         if (cols is None) and (self.cached_data is not None):

--- a/finrl/meta/env_stock_trading/env_stocktrading_stoploss.py
+++ b/finrl/meta/env_stock_trading/env_stocktrading_stoploss.py
@@ -167,7 +167,7 @@ class StockTradingEnvStopLoss(gym.Env):
             + self.get_date_vector(self.date_index)
         )
         self.state_memory.append(init_state)
-        return init_state
+        return init_state, {}
 
     def get_date_vector(self, date, cols=None):
         if (cols is None) and (self.cached_data is not None):


### PR DESCRIPTION
## Summary
Four environments' `reset()` methods return only the observation instead of the `(obs, info)` tuple required by the Gymnasium API (and SB3 v2.0+), causing `ValueError: too many values to unpack (expected 2)` when used with `DummyVecEnv`.

## Fixed Environments
- `env_btc_ccxt.py` (BitcoinEnv)
- `env_multiple_crypto.py` (CryptoEnv) 
- `env_stocktrading_stoploss.py` (StockTradingEnvStopLoss)
- `env_stocktrading_cashpenalty.py` (StockTradingEnvCashpenalty)

Note: `env_stocktrading.py` and `env_stocktrading_np.py` already return `(obs, {})` correctly.

## Change
Each fix is a single-line change: `return state` → `return state, {}`

## Test plan
- [ ] Verify `DummyVecEnv` wrapping works with each fixed environment
- [ ] Verify training with SB3 PPO/A2C works without the unpacking error

Fixes #1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)