### PR TITLE
Fix TensorboardCallback logging for off-policy algorithms

### DIFF
--- a/finrl/agents/stablebaselines3/models.py
+++ b/finrl/agents/stablebaselines3/models.py
@@ -57,18 +57,33 @@ class TensorboardCallback(BaseCallback):
 
     def _on_rollout_end(self) -> bool:
         try:
-            rollout_buffer_rewards = self.locals["rollout_buffer"].rewards.flatten()
-            self.logger.record(
-                key="train/reward_min", value=min(rollout_buffer_rewards)
-            )
-            self.logger.record(
-                key="train/reward_mean", value=statistics.mean(rollout_buffer_rewards)
-            )
-            self.logger.record(
-                key="train/reward_max", value=max(rollout_buffer_rewards)
-            )
+            # On-policy algorithms (A2C, PPO) use rollout_buffer
+            if "rollout_buffer" in self.locals:
+                rewards = self.locals["rollout_buffer"].rewards.flatten()
+            # Off-policy algorithms (DDPG, TD3, SAC) use replay_buffer
+            elif hasattr(self.model, "replay_buffer") and self.model.replay_buffer is not None:
+                buf = self.model.replay_buffer
+                if buf.full:
+                    rewards = buf.rewards[:buf.buffer_size].flatten()
+                elif buf.pos > 0:
+                    rewards = buf.rewards[:buf.pos].flatten()
+                else:
+                    return True
+            else:
+                return True
+
+            if len(rewards) > 0:
+                self.logger.record(
+                    key="train/reward_min", value=float(min(rewards))
+                )
+                self.logger.record(
+                    key="train/reward_mean",
+                    value=float(statistics.mean(rewards)),
+                )
+                self.logger.record(
+                    key="train/reward_max", value=float(max(rewards))
+                )
         except BaseException as error:
-            # Handle the case where "rewards" is not found
             self.logger.record(key="train/reward_min", value=None)
             self.logger.record(key="train/reward_mean", value=None)
             self.logger.record(key="train/reward_max", value=None)


### PR DESCRIPTION
## Summary

- Fixes #1395
- The `TensorboardCallback._on_rollout_end` method assumed `rollout_buffer` was always present in `self.locals`, but off-policy algorithms (DDPG, TD3, SAC) use `replay_buffer` instead. This caused a `KeyError` every rollout, falling through to the except block which logged `None` values and printed noisy error messages.
- The fix checks which buffer type is available: `rollout_buffer` from locals for on-policy algorithms (A2C, PPO), or `replay_buffer` from the model for off-policy algorithms (DDPG, TD3, SAC). If neither exists, the callback returns early without logging errors.

## What changed

In `finrl/agents/stablebaselines3/models.py`, the `_on_rollout_end` method now:

1. Checks for `rollout_buffer` in `self.locals` first (on-policy path, same as before)
2. Falls back to `self.model.replay_buffer` for off-policy algorithms, reading only the valid portion of the buffer (up to `buf.pos` or the full `buf.buffer_size` if the buffer has wrapped)
3. Returns early if neither buffer is available, instead of raising and catching an exception

## Test plan

- [ ] Train with an on-policy algorithm (A2C or PPO) and confirm TensorBoard reward stats still log correctly
- [ ] Train with an off-policy algorithm (DDPG, TD3, or SAC) and confirm reward stats now log actual values instead of `None`
- [ ] Verify no `Logging Error:` messages are printed to stdout during off-policy training