### PR TITLE
fix(benchmark): compare agents against DJIA total return (DIA baseline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ This script trains 5 DRL agents (A2C, DDPG, PPO, TD3, SAC) using Stable Baseline
 python examples/FinRL_StockTrading_2026_3_Backtest.py
 ```
 
-This script loads the trained agents, runs them on the trading data, and compares their performance against two baselines: Mean Variance Optimization (MVO) and the DJIA index. Results are printed to the console and a plot is saved as `backtest_result.png`.
+This script loads the trained agents, runs them on the trading data, and compares their performance against two baselines: Mean Variance Optimization (MVO) and the DJIA index (total return, via the DIA ETF). Results are printed to the console and a plot is saved as `backtest_result.png`.
 
 
 ## File Structure

--- a/examples/FinRL_StockTrading_2026_3_Backtest.py
+++ b/examples/FinRL_StockTrading_2026_3_Backtest.py
@@ -152,7 +152,12 @@ MVO_result = pd.DataFrame(Portfolio_Assets, columns=["Mean Var"])
 
 import yfinance as yf
 
-df_dji = yf.download("^DJI", start=TRADE_START_DATE, end=TRADE_END_DATE)
+# DIA is the DJIA-tracking ETF; adjusted prices include dividends, so the
+# baseline uses the same total-return convention as the agent's account
+# value. ^DJI is a price-return index and would understate the baseline.
+df_dji = yf.download(
+    "DIA", start=TRADE_START_DATE, end=TRADE_END_DATE, auto_adjust=True
+)
 df_dji = df_dji[["Close"]].reset_index()
 df_dji.columns = ["date", "close"]
 df_dji["date"] = df_dji["date"].astype(str)

--- a/finrl/plot.py
+++ b/finrl/plot.py
@@ -51,7 +51,7 @@ def backtest_plot(
     account_value,
     baseline_start=config.TRADE_START_DATE,
     baseline_end=config.TRADE_END_DATE,
-    baseline_ticker="^DJI",
+    baseline_ticker="DIA",
     value_col_name="account_value",
 ):
     df = deepcopy(account_value)
@@ -74,6 +74,9 @@ def backtest_plot(
 
 
 def get_baseline(ticker, start, end):
+    # DIA (a DJIA-tracking ETF) is the default baseline because the
+    # downloader adjusts close prices for dividends, matching the
+    # total-return basis of the agent's account value.
     return YahooDownloader(
         start_date=start, end_date=end, ticker_list=[ticker]
     ).fetch_data()


### PR DESCRIPTION
Fixes #1434

## Summary

The tutorial compares agents that trade dividend-adjusted (total-return) prices against a `^DJI` baseline, which is a **price-return** index. The two sides therefore use different return definitions, and the reported gap includes the DJIA dividend stream (~+1.92%/yr over 2018-2025, per the issue's measurement) regardless of agent behavior.

This PR makes the baseline total-return too:

- `examples/FinRL_StockTrading_2026_3_Backtest.py`: download `DIA` (the DJIA-tracking ETF) with `auto_adjust=True` instead of `^DJI`, with a comment explaining the convention.
- `finrl/plot.py`: change the `backtest_plot` default `baseline_ticker` from `^DJI` to `DIA`. `get_baseline` already routes through `YahooDownloader`, which adjusts close prices for distributions, so the plotted baseline now matches the agent's total-return account value.
- `README.md`: clarify that the DJIA baseline is total return via the DIA ETF.

## Notes

- `DIA` carries a small expense ratio (~0.16%/yr), so it slightly understates a pure DJIA total-return index; it is used because it needs no new data source (as discussed in #1434).
- The agent input convention (Adj Close) is intentionally unchanged; only the comparison side is fixed.

## Validation

- `black --check` on both modified Python files: pass
- `flake8` on both modified Python files: no new issues (remaining warnings are pre-existing)
- Live yfinance re-download was rate-limited on this machine; the +1.92%/yr convention estimate in #1434 was measured independently over 2018-2025.