### PR TITLE
Fix YahooFinanceProcessor scrap_data ticker sorting

### DIFF
--- a/finrl/meta/data_processors/processor_yahoofinance.py
+++ b/finrl/meta/data_processors/processor_yahoofinance.py
@@ -173,7 +173,7 @@ class YahooFinanceProcessor:
                 print(f"Error fetching data for {stock_name}: {e}")
 
         combined_df = pd.concat(all_dataframes, ignore_index=True)
-        combined_df = combined_df.sort_values(by=["day", "tick"]).reset_index(drop=True)
+        combined_df = combined_df.sort_values(by=["day", "tic"]).reset_index(drop=True)
 
         return combined_df
 

--- a/unit_tests/data_processors/test_processor_yahoofinance.py
+++ b/unit_tests/data_processors/test_processor_yahoofinance.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from importlib.util import module_from_spec
+from importlib.util import spec_from_file_location
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+import pandas as pd
+
+_PROCESSOR_PATH = (
+    Path(__file__).parents[2]
+    / "finrl"
+    / "meta"
+    / "data_processors"
+    / "processor_yahoofinance.py"
+)
+_SPEC = spec_from_file_location("processor_yahoofinance_under_test", _PROCESSOR_PATH)
+if _SPEC is None or _SPEC.loader is None:
+    raise ImportError(f"Unable to load {_PROCESSOR_PATH}")
+_PROCESSOR_MODULE = module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_PROCESSOR_MODULE)
+YahooFinanceProcessor = _PROCESSOR_MODULE.YahooFinanceProcessor
+
+
+class TestYahooFinanceProcessor(TestCase):
+    def test_scrap_data_sorts_by_day_and_tic(self):
+        processor = YahooFinanceProcessor()
+        stock_data = {
+            "BBB": pd.DataFrame({"day": [1, 0], "tic": ["BBB", "BBB"]}),
+            "AAA": pd.DataFrame({"day": [1, 0], "tic": ["AAA", "AAA"]}),
+        }
+
+        def fake_fetch_stock_data(stock_name, period1, period2):
+            return stock_data[stock_name]
+
+        with patch.object(
+            processor, "fetch_stock_data", side_effect=fake_fetch_stock_data
+        ):
+            result = processor.scrap_data(
+                stock_names=["BBB", "AAA"],
+                start_date="2020-01-01",
+                end_date="2020-01-03",
+            )
+
+        self.assertEqual(
+            result[["day", "tic"]].to_dict("records"),
+            [
+                {"day": 0, "tic": "AAA"},
+                {"day": 0, "tic": "BBB"},
+                {"day": 1, "tic": "AAA"},
+                {"day": 1, "tic": "BBB"},
+            ],
+        )


### PR DESCRIPTION
## Summary

- Fix `scrap_data()` sorting to use the `tic` column produced by `fetch_stock_data()`.
- Add a network-free regression test covering multiple symbols and days.

Fixes #1436

## Validation

- `pytest -q unit_tests/data_processors/test_processor_yahoofinance.py`
- `python -m unittest discover -s unit_tests -p "test_processor_yahoofinance.py" -q`
- `git diff --check`

@bruceyang