### PR TITLE
Fix CCXTEngineer.data_fetch timestamps drifting with the local timezone (#1440)

### DIFF
--- a/finrl/meta/data_processors/processor_ccxt.py
+++ b/finrl/meta/data_processors/processor_ccxt.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import calendar
 from datetime import datetime
+from datetime import timezone
 
 import ccxt
 import numpy as np
@@ -14,6 +15,13 @@ class CCXTEngineer:
         self.binance = ccxt.binance()
 
     def data_fetch(self, start, end, pair_list=["BTC/USDT"], period="1m"):
+        """Download OHLCV bars from Binance for each pair in ``pair_list``.
+
+        ``start`` and ``end`` (``"%Y%m%d %H:%M:%S"``) are interpreted as UTC, and the
+        index of the returned DataFrame holds naive UTC timestamps, independent of the
+        local timezone of the machine.
+        """
+
         def min_ohlcv(dt, pair, limit):
             since = calendar.timegm(dt.utctimetuple()) * 1000
             ohlcv = self.binance.fetch_ohlcv(
@@ -46,9 +54,11 @@ class CCXTEngineer:
             df = pd.DataFrame(
                 ohlcv, columns=["time", "open", "high", "low", "close", "volume"]
             )
-            df["time"] = [
-                datetime.fromtimestamp(float(time) / 1000) for time in df["time"]
-            ]
+            # Binance stamps bars in UTC milliseconds; keep the index in UTC (naive)
+            # rather than the local timezone of the machine running the download.
+            df["time"] = pd.to_datetime(df["time"], unit="ms", utc=True).dt.tz_localize(
+                None
+            )
             df["open"] = df["open"].astype(np.float64)
             df["high"] = df["high"].astype(np.float64)
             df["low"] = df["low"].astype(np.float64)
@@ -67,12 +77,12 @@ class CCXTEngineer:
             end_timestamp = calendar.timegm(end_dt.utctimetuple())
             if period == "1m":
                 date_list = [
-                    datetime.utcfromtimestamp(float(time))
+                    datetime.fromtimestamp(float(time), tz=timezone.utc)
                     for time in range(start_timestamp, end_timestamp, 60 * 720)
                 ]
             else:
                 date_list = [
-                    datetime.utcfromtimestamp(float(time))
+                    datetime.fromtimestamp(float(time), tz=timezone.utc)
                     for time in range(start_timestamp, end_timestamp, 60 * 1440)
                 ]
             df = ohlcv(date_list, pair, period)

--- a/unit_tests/downloaders/test_ccxt_processor.py
+++ b/unit_tests/downloaders/test_ccxt_processor.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os
+import time
+import warnings
+
+import pandas as pd
+import pytest
+
+from finrl.meta.data_processors.processor_ccxt import CCXTEngineer
+
+
+@pytest.fixture
+def engineer():
+    def fake_fetch_ohlcv(symbol, timeframe, since, limit):
+        return [
+            [since + i * 3_600_000, 1.0, 2.0, 0.5, 1.5, 100.0] for i in range(limit)
+        ]
+
+    eng = CCXTEngineer()
+    eng.binance.fetch_ohlcv = fake_fetch_ohlcv
+    return eng
+
+
+# The pre-fix code converted timestamps with the machine's local time, so a
+# non-UTC zone is needed for these tests to fail against it.
+@pytest.fixture
+def new_york_tz():
+    previous_tz = os.environ.get("TZ")
+    os.environ["TZ"] = "America/New_York"
+    time.tzset()
+    yield
+    if previous_tz is None:
+        del os.environ["TZ"]
+    else:
+        os.environ["TZ"] = previous_tz
+    time.tzset()
+
+
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="time.tzset is Unix-only")
+def test_index_is_utc_regardless_of_local_timezone(engineer, new_york_tz):
+    dataset = engineer.data_fetch(
+        "20240101 00:00:00", "20240102 00:00:00", pair_list=["BTC/USDT"], period="1h"
+    )
+
+    # Before the fix this index started at 2023-12-31 19:00 in New York.
+    assert dataset.index[0] == pd.Timestamp("2024-01-01 00:00:00")
+    assert dataset.index[-1] == pd.Timestamp("2024-01-01 23:00:00")
+    assert len(dataset) == 24
+    assert dataset.index.tz is None
+
+
+@pytest.mark.skipif(not hasattr(time, "tzset"), reason="time.tzset is Unix-only")
+def test_index_is_monotonic_across_dst_fall_back(engineer, new_york_tz):
+    # New York falls back on 2024-11-03, so local-time conversion repeats 01:00.
+    dataset = engineer.data_fetch(
+        "20241103 00:00:00", "20241104 00:00:00", pair_list=["BTC/USDT"], period="1h"
+    )
+
+    assert dataset.index.is_monotonic_increasing
+    assert dataset.index.is_unique
+    assert len(dataset) == 24
+
+
+def test_multiple_pairs_share_the_same_index(engineer):
+    dataset = engineer.data_fetch(
+        "20240101 00:00:00",
+        "20240102 00:00:00",
+        pair_list=["BTC/USDT", "ETH/USDT"],
+        period="1h",
+    )
+
+    assert dataset.shape == (24, 10)
+    assert dataset[("ETH/USDT", "close")].notna().all()
+
+
+def test_no_deprecation_warning(engineer):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        engineer.data_fetch(
+            "20240101 00:00:00",
+            "20240102 00:00:00",
+            pair_list=["BTC/USDT"],
+            period="1h",
+        )


### PR DESCRIPTION
Fixes #1440

## Problem

`CCXTEngineer.data_fetch` builds its request window in UTC and Binance returns bar timestamps as UTC milliseconds, but the returned index was produced with `datetime.fromtimestamp(ms / 1000)`, which uses the local timezone of the machine. On any box not set to UTC every timestamp is shifted by the local offset, and across a DST fall-back the index repeats an hour, which breaks the positional assignment of the second and later pairs and any later `.loc` slicing. Two people running the same notebook in different timezones get different dates for the same bars.

| ms from Binance | before (machine in New York) | after |
|---|---|---|
| `1704067200000` | `2023-12-31 19:00:00` | `2024-01-01 00:00:00` |

## Fix

Timestamps are now **naive UTC**: the millisecond column is converted with `pd.to_datetime(..., unit="ms", utc=True).dt.tz_localize(None)`. I chose naive over tz-aware because the index dtype stays `datetime64[ns]` exactly as today, so `add_technical_indicators`, `df_to_ary`, `CryptoEnv` and the crypto notebooks see no change in type, and it matches `date_list`, which is already built as UTC. A docstring on `data_fetch` now states that `start`/`end` and the returned index are UTC. If you would prefer a tz-aware `datetime64[ns, UTC]` index as in the issue's proposed diff, that is a one-line change and I'm happy to switch.

The same function used `datetime.utcfromtimestamp`, deprecated since Python 3.12; both calls are replaced with `datetime.fromtimestamp(..., tz=timezone.utc)`. `calendar.timegm(dt.utctimetuple())` gives the same `since` value for aware and naive UTC datetimes, so the request windows are unchanged.

Nothing else in the file is touched.

## Test

`unit_tests/downloaders/test_ccxt_processor.py` never hits the network: it stubs `binance.fetch_ohlcv` with synthetic hourly rows, forces `TZ=America/New_York` via `time.tzset()` (skipped on Windows), and asserts that the index for `1704067200000` is `2024-01-01 00:00:00`, that it stays strictly increasing and unique across the 2024-11-03 fall-back, that two pairs share one index, and that `data_fetch` raises no `DeprecationWarning`. The first two tests fail on current `master`.

## Checks

- `pytest unit_tests/downloaders/test_ccxt_processor.py -q`: 4 passed (and 2 failed when run against `master`)
- `pre-commit run --files ...`: all hooks pass (reorder-python-imports, pyupgrade, black, flake8)

@tarun1790, this should cover the case in your report; let me know if anything is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Rf4jRK6VVz9qZQ9fcDErw
